### PR TITLE
Eclipse import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.classpath
+.project
+.settings
+.idea
+.*DS_Store
+*.iml
+build/
+out/
+target/

--- a/clas-detector/pom.xml
+++ b/clas-detector/pom.xml
@@ -1,47 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.jlab.clas</groupId>
+  <artifactId>clas-detector</artifactId>
+  <version>3.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
     <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-detector</artifactId>
+    <artifactId>clas12rec</artifactId>
+    <relativePath>../parent/pom.xml</relativePath>
     <version>3.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+  </parent>
 
-    <parent>
+  <dependencies>
+    <dependency>
       <groupId>org.jlab.clas</groupId>
-      <artifactId>clas12rec</artifactId>
-      <relativePath>../parent/pom.xml</relativePath>
+      <artifactId>clas-utils</artifactId>
       <version>3.0-SNAPSHOT</version>
-    </parent>
+    </dependency>
 
-    <dependencies>
-      <dependency>
-        <groupId>org.jlab.clas</groupId>
-        <artifactId>clas-utils</artifactId>
-        <version>3.0-SNAPSHOT</version>
-      </dependency>
-      
-      <dependency>
-        <groupId>org.jlab.clas</groupId>
-        <artifactId>clas-io</artifactId>
-        <version>3.0-SNAPSHOT</version>
-      </dependency> 
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-io</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency> 
 
-      <dependency>
-	<groupId>org.jlab.clas</groupId>
-	<artifactId>clas-geometry</artifactId>
-	<version>3.0-SNAPSHOT</version>
-      </dependency>      
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-geometry</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
 
-      <dependency>
-        <groupId>org.jlab</groupId>
-        <artifactId>groot</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
-      </dependency>
-    </dependencies>
+    <dependency>
+      <groupId>org.jlab</groupId>
+      <artifactId>groot</artifactId>
+      <version>1.1.1-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
 
-
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 </project>

--- a/clas-geometry/pom.xml
+++ b/clas-geometry/pom.xml
@@ -1,28 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.jlab.clas</groupId>
+  <artifactId>clas-geometry</artifactId>
+  <version>3.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <parent>
     <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-geometry</artifactId>
+    <artifactId>clas12rec</artifactId>
+    <relativePath>../parent/pom.xml</relativePath>
     <version>3.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-    <parent>
-      <groupId>org.jlab.clas</groupId>
-      <artifactId>clas12rec</artifactId>
-      <relativePath>../parent/pom.xml</relativePath>
-      <version>3.0-SNAPSHOT</version>
-    </parent>
+  </parent>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jlab.ccdb</groupId>
+      <artifactId>ccdb</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
 
-    <dependencies>    
-      <dependency>
-	<groupId>org.jlab.ccdb</groupId>
-	<artifactId>ccdb</artifactId>
-	<version>1.0</version>
-      </dependency>
-    </dependencies>
-
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 </project>

--- a/clas-io/pom.xml
+++ b/clas-io/pom.xml
@@ -1,57 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-io</artifactId>
-    <version>3.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-    
-    <parent>
-      <groupId>org.jlab.clas</groupId>
-      <artifactId>clas12rec</artifactId>
-      <relativePath>../parent/pom.xml</relativePath>
-      <version>3.0-SNAPSHOT</version>
-    </parent>
-    
-    <dependencies>
-      <dependency>
-	<groupId>org.jlab.coda</groupId>
-        <artifactId>jevio</artifactId>
-        <version>4.4.6</version>
-      </dependency>
-
-     <dependency>
-        <groupId>org.hep.hipo</groupId>
-        <artifactId>hipo</artifactId>
-        <version>2.0-SNAPSHOT</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jlab.coda</groupId>
-        <artifactId>et</artifactId>
-        <version>14.0</version> 
-      </dependency>
-      <dependency>
-	<groupId>org.jlab.coda</groupId>
-	<artifactId>xmsg</artifactId>
-	<version>2.3-SNAPSHOT</version>
-      </dependency>
-<!--
-      <dependency>
-        <groupId>org.jlab.clas</groupId>
-        <artifactId>clas-tools</artifactId>
-        <version>2.4-SNAPSHOT</version>
-      </dependency>      
- -->     
-<dependency>
+  <modelVersion>4.0.0</modelVersion>
   <groupId>org.jlab.clas</groupId>
-  <artifactId>clas-utils</artifactId>
+  <artifactId>clas-io</artifactId>
   <version>3.0-SNAPSHOT</version>
-</dependency>
+  <packaging>jar</packaging>
 
-    </dependencies>
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+  <parent>
+    <groupId>org.jlab.clas</groupId>
+    <artifactId>clas12rec</artifactId>
+    <relativePath>../parent/pom.xml</relativePath>
+    <version>3.0-SNAPSHOT</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>jevio</artifactId>
+      <version>4.4.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hep.hipo</groupId>
+      <artifactId>hipo</artifactId>
+      <version>2.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>et</artifactId>
+      <version>14.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>xmsg</artifactId>
+      <version>2.3-SNAPSHOT</version>
+    </dependency>
+
+<!--
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-tools</artifactId>
+      <version>2.4-SNAPSHOT</version>
+    </dependency>
+-->
+
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-utils</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
 </project>

--- a/clas-physics/pom.xml
+++ b/clas-physics/pom.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.jlab.clas</groupId>
+  <artifactId>clas-physics</artifactId>
+  <version>3.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <parent>
     <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-physics</artifactId>
+    <artifactId>clas12rec</artifactId>
+    <relativePath>../parent/pom.xml</relativePath>
     <version>3.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
-    <parent>
-      <groupId>org.jlab.clas</groupId>
-      <artifactId>clas12rec</artifactId>
-      <relativePath>../parent/pom.xml</relativePath>
-      <version>3.0-SNAPSHOT</version>
-    </parent>
-    
+  </parent>
 </project>

--- a/clas-reco/pom.xml
+++ b/clas-reco/pom.xml
@@ -1,84 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.jlab.clas</groupId>
+  <artifactId>clas-reco</artifactId>
+  <version>3.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
     <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-reco</artifactId>
+    <artifactId>clas12rec</artifactId>
+    <relativePath>../parent/pom.xml</relativePath>
     <version>3.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+  </parent>
 
-    <parent>
-      <groupId>org.jlab.clas</groupId>
-      <artifactId>clas12rec</artifactId>
-      <relativePath>../parent/pom.xml</relativePath>
-      <version>3.0-SNAPSHOT</version>
-    </parent>
+  <dependencies>
 
-    <dependencies>
+    <dependency>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>jclara</artifactId>
+      <version>4.3-SNAPSHOT</version>
+    </dependency>
 
-     <dependency>
-        <groupId>org.jlab.coda</groupId>
-	<artifactId>jclara</artifactId>
-	<version>4.3-SNAPSHOT</version>
-      </dependency>
+    <dependency>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>jtools</artifactId>
+      <version>2.2</version>
+    </dependency>
 
-     <dependency>
-        <groupId>org.jlab.coda</groupId>
-        <artifactId>jtools</artifactId>
-        <version>2.2</version>
-      </dependency>
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>magfield</artifactId>
+      <version>2.0-SNAPSHOT</version>
+    </dependency>
 
-     <dependency>
-        <groupId>cnuphys</groupId>
-        <artifactId>magfield</artifactId>
-        <version>2.0-SNAPSHOT</version>
-     </dependency>
-     <dependency>
-        <groupId>cnuphys</groupId>
-        <artifactId>swimmer</artifactId>
-        <version>2.0-SNAPSHOT</version>
-     </dependency>
-     <dependency>
-       <groupId>cnuphys</groupId>
-       <artifactId>snr</artifactId>
-       <version>2.0-SNAPSHOT</version>
-     </dependency>
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>swimmer</artifactId>
+      <version>2.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>snr</artifactId>
+      <version>2.0-SNAPSHOT</version>
+    </dependency>
+
 <!--
-     <dependency>
-       <groupId>org.jlab.ccdb</groupId>
-       <artifactId>ccdb</artifactId>
-       <version>1.0</version>
-     </dependency>
+    <dependency>
+      <groupId>org.jlab.ccdb</groupId>
+      <artifactId>ccdb</artifactId>
+      <version>1.0</version>
+    </dependency>
 -->
-     <dependency>
-        <groupId>org.jlab.clas</groupId>
-        <artifactId>clas-io</artifactId>
-        <version>3.0-SNAPSHOT</version>
-      </dependency>     
 
-     <dependency>
-        <groupId>org.jlab.clas</groupId>
-        <artifactId>clas-physics</artifactId>
-        <version>3.0-SNAPSHOT</version>
-     </dependency>
-     
-     <dependency>
-        <groupId>org.jlab.clas</groupId>
-        <artifactId>clas-utils</artifactId>
-        <version>3.0-SNAPSHOT</version>
-     </dependency>
-     
-     <dependency>
-       <groupId>org.jlab.clas</groupId>
-       <artifactId>clas-detector</artifactId>
-       <version>3.0-SNAPSHOT</version>
-     </dependency>
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-io</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
 
-     <!--
-     <dependency>
-        <groupId>org.jlab.clas</groupId>
-        <artifactId>clas-geometry</artifactId>
-        <version>3.0-SNAPSHOT</version>
-      </dependency> -->
-    </dependencies>
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-physics</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-utils</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-detector</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
+
+<!--
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-geometry</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
+-->
+
+  </dependencies>
 
 </project>

--- a/clas-reco/pom.xml
+++ b/clas-reco/pom.xml
@@ -87,4 +87,9 @@
 
   </dependencies>
 
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
 </project>

--- a/clas-utils/pom.xml
+++ b/clas-utils/pom.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.jlab.clas</groupId>
+  <artifactId>clas-utils</artifactId>
+  <version>3.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
     <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-utils</artifactId>
+    <artifactId>clas12rec</artifactId>
+    <relativePath>../parent/pom.xml</relativePath>
     <version>3.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+  </parent>
 
-    <parent>
-      <groupId>org.jlab.clas</groupId>
-      <artifactId>clas12rec</artifactId>
-      <relativePath>../parent/pom.xml</relativePath>
-      <version>3.0-SNAPSHOT</version>
-    </parent>
+  <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-math3 -->
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+      <version>3.6.1</version>
+    </dependency>
+  </dependencies>
 
-    <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-math3 -->
-    <dependencies>
-      <dependency>
-	<groupId>org.apache.commons</groupId>
-	<artifactId>commons-math3</artifactId>
-	<version>3.6.1</version>
-      </dependency>
-    </dependencies>
-    
-    <properties>
-      <maven.compiler.target>1.8</maven.compiler.target>
-      <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
 
 </project>

--- a/coat-lib/pom.xml
+++ b/coat-lib/pom.xml
@@ -8,11 +8,11 @@
 
   <!--
   <parent>
-        <groupId>org.jlab.coat</groupId>
-        <artifactId>coat-clas-parent</artifactId>
-        <relativePath>../parent/pom.xml</relativePath>
-        <version>1.0-SNAPSHOT</version>
-  </parent>  
+    <groupId>org.jlab.coat</groupId>
+    <artifactId>coat-clas-parent</artifactId>
+    <relativePath>../parent/pom.xml</relativePath>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
   -->
 
   <repositories>
@@ -22,242 +22,244 @@
     </repository>
   </repositories>
 
-<!-- project Dependencies -->
+  <!-- project Dependencies -->
 
-<dependencies>
-  <dependency>
-    <groupId>org.jlab.coda</groupId>
-    <artifactId>jevio</artifactId>
-    <version>4.4.6</version>
-  </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>jevio</artifactId>
+      <version>4.4.6</version>
+    </dependency>
 
-  <dependency>
-    <groupId>org.hep.hipo</groupId>
-    <artifactId>hipo</artifactId>
-    <version>2.0-SNAPSHOT</version>
-  </dependency>
+    <dependency>
+      <groupId>org.hep.hipo</groupId>
+      <artifactId>hipo</artifactId>
+      <version>2.0-SNAPSHOT</version>
+    </dependency>
 
- <dependency>
-    <groupId>org.jlab.coda</groupId>
-    <artifactId>et</artifactId>
-    <version>14.0</version>
-  </dependency>
+    <dependency>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>et</artifactId>
+      <version>14.0</version>
+    </dependency>
 
-  <dependency>
-    <groupId>org.jlab.coda</groupId>
-    <artifactId>jclara</artifactId>
-    <version>4.3-SNAPSHOT</version>
-  </dependency>
-
-<!--
-  <dependency>
-    <groupId>org.jama</groupId>
-    <artifactId>jama</artifactId>
-    <version>1.0</version>
-  </dependency>
--->
-  <dependency>
-    <groupId>org.jama</groupId>
-    <artifactId>jamapack</artifactId>
-    <version>1.0</version>
-  </dependency>
-
-  <dependency>
-    <groupId>org.jlab.plugins</groupId>
-    <artifactId>trackfitter</artifactId>
-    <version>1.0</version>
-  </dependency>
-  
-  <dependency>
-    <groupId>org.jlab.plugins</groupId>
-    <artifactId>jMath</artifactId>
-    <version>1.0</version>
-  </dependency>
-
-  <dependency>
-    <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-io</artifactId>
-    <version>3.0-SNAPSHOT</version>
-  </dependency>
-
-  <dependency>
-    <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-reco</artifactId>
-    <version>3.0-SNAPSHOT</version>
-  </dependency>
-
-  <dependency>
-    <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-utils</artifactId>
-    <version>3.0-SNAPSHOT</version>
-  </dependency>
-
-  <dependency>
-    <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-detector</artifactId>
-    <version>3.0-SNAPSHOT</version>
-  </dependency>
-
-  <dependency>
-    <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-geometry</artifactId>
-    <version>3.0-SNAPSHOT</version>
-  </dependency>
-
-  <dependency>
-    <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-physics</artifactId>
-    <version>3.0-SNAPSHOT</version>
-  </dependency>
-<!--
-  <dependency>
-    <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-reco</artifactId>
-    <version>3.0-SNAPSHOT</version>
-  </dependency>
-
-  <dependency>
-    <groupId>org.jlab.clas</groupId>
-    <artifactId>clas-detector</artifactId>
-    <version>3.0-SNAPSHOT</version>
-  </dependency>
--->
-
-  <dependency>
-    <groupId>org.freehep</groupId>
-    <artifactId>jminuit</artifactId>
-    <version>1.0</version>
-  </dependency>
-  
-  <dependency>
-    <groupId>de.erichseifert</groupId>
-    <artifactId>vectorgraphics2d</artifactId>
-    <version>1.0</version>
-  </dependency>
-
-  <dependency>
-    <groupId>net.objecthunter</groupId>
-    <artifactId>exp4j</artifactId>
-    <version>0.4.4</version>
-  </dependency>
-
+    <dependency>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>jclara</artifactId>
+      <version>4.3-SNAPSHOT</version>
+    </dependency>
 
 <!--
-  <dependency>
-    <groupId>cnuphys</groupId>
-    <artifactId>swimmer</artifactId>
-    <version>1.0</version>
-  </dependency>
+    <dependency>
+      <groupId>org.jama</groupId>
+      <artifactId>jama</artifactId>
+      <version>1.0</version>
+    </dependency>
+-->
 
-  <dependency>
-    <groupId>cnuphys</groupId>
-    <artifactId>magfield</artifactId>
-    <version>1.0</version>
-  </dependency>
+    <dependency>
+      <groupId>org.jama</groupId>
+      <artifactId>jamapack</artifactId>
+      <version>1.0</version>
+    </dependency>
 
-  <dependency>
-    <groupId>cnuphys</groupId>
-    <artifactId>snr</artifactId>
-    <version>1.0</version>
-  </dependency>  
+    <dependency>
+      <groupId>org.jlab.plugins</groupId>
+      <artifactId>trackfitter</artifactId>
+      <version>1.0</version>
+    </dependency>
 
-  <dependency>
-    <groupId>cnuphys</groupId>
-    <artifactId>bCNU</artifactId>
-    <version>1.0</version>
-  </dependency>
+    <dependency>
+      <groupId>org.jlab.plugins</groupId>
+      <artifactId>jMath</artifactId>
+      <version>1.0</version>
+    </dependency>
 
-  <dependency>
-    <groupId>cnuphys</groupId>
-    <artifactId>bcnuimages</artifactId>
-    <version>1.0</version>
-  </dependency>
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-io</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
 
-  <dependency>
-    <groupId>cnuphys</groupId>
-    <artifactId>splot</artifactId>
-    <version>1.0</version>
-  </dependency>
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-reco</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
 
-  <dependency>
-    <groupId>cnuphys</groupId>
-    <artifactId>splotimages</artifactId>
-    <version>1.0</version>
-  </dependency>
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-utils</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
 
-  <dependency>
-    <groupId>cnuphys</groupId>
-    <artifactId>f2jutil</artifactId>
-    <version>1.0</version>
-  </dependency>
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-detector</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
 
-  <dependency>
-    <groupId>cnuphys</groupId>
-    <artifactId>numRec</artifactId>
-    <version>1.0</version>
-  </dependency>
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-geometry</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-physics</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
+
+    <!--
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-reco</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-detector</artifactId>
+      <version>3.0-SNAPSHOT</version>
+    </dependency>
+    -->
+
+    <dependency>
+      <groupId>org.freehep</groupId>
+      <artifactId>jminuit</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>de.erichseifert</groupId>
+      <artifactId>vectorgraphics2d</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>net.objecthunter</groupId>
+      <artifactId>exp4j</artifactId>
+      <version>0.4.4</version>
+    </dependency>
+
+<!--
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>swimmer</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>magfield</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>snr</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>bCNU</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>bcnuimages</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>splot</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>splotimages</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>f2jutil</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>numRec</artifactId>
+      <version>1.0</version>
+    </dependency>
+
 -->
 <!--
-  <dependency>
-    <groupId>cnuphys</groupId>
-    <artifactId>cnuphys</artifactId>
-    <version>2.0-SNAPSHOT</version>
-  </dependency>
+    <dependency>
+      <groupId>cnuphys</groupId>
+      <artifactId>cnuphys</artifactId>
+      <version>2.0-SNAPSHOT</version>
+    </dependency>
 -->
-</dependencies>
+  </dependencies>
 
-<!-- BUILD section for creating one JAR -->
-<build>
-  <finalName>coatjava</finalName>
-  <plugins>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-shade-plugin</artifactId>
-      <version>2.3</version>
-      <configuration>
-	<outputFile>target/coat-libs-${project.version}.jar</outputFile>
-	<artifactSet>
-          <excludes>
-            <exclude>cnuphys:cnuphys</exclude>
-            <!-- <exclude>cnuphys:magfield</exclude>
-            <exclude>cnuphys:swimmer</exclude> -->
-            <exclude>cnuphys:bCNU</exclude>
-            <exclude>cnuphys:bCNU3D</exclude>
-            <exclude>cnuphys:jogl-all</exclude>
-            <exclude>cnuphys:jogl</exclude>
-            <exclude>cnuphys:gluegen</exclude>
-            <exclude>org.jlab.coda:jclara</exclude>
-	    <!--            <exclude>org.jlab.coda:jevio</exclude> -->
-          </excludes>
-	</artifactSet>
-	<filters>
-          <filter>
-            <artifact>*:*</artifact>
+  <!-- BUILD section for creating one JAR -->
+  <build>
+    <finalName>coatjava</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.3</version>
+        <configuration>
+          <outputFile>target/coat-libs-${project.version}.jar</outputFile>
+          <artifactSet>
             <excludes>
-              <exclude>META-INF/*.SF</exclude>
-              <exclude>META-INF/*.DSA</exclude>
-              <exclude>META-INF/*.RSA</exclude>
+              <exclude>cnuphys:cnuphys</exclude>
+              <!-- <exclude>cnuphys:magfield</exclude> -->
+              <!-- <exclude>cnuphys:swimmer</exclude> -->
+              <exclude>cnuphys:bCNU</exclude>
+              <exclude>cnuphys:bCNU3D</exclude>
+              <exclude>cnuphys:jogl-all</exclude>
+              <exclude>cnuphys:jogl</exclude>
+              <exclude>cnuphys:gluegen</exclude>
+              <exclude>org.jlab.coda:jclara</exclude>
+              <!-- <exclude>org.jlab.coda:jevio</exclude> -->
             </excludes>
-          </filter>
-	</filters>
-	<!--
-	    <artifactSet>
+          </artifactSet>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
               <excludes>
-		<exclude>org.jlab.coda:jclara</exclude>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
               </excludes>
-            </artifactSet>
-	    -->
-      </configuration>
-      <executions>
-        <execution>
-          <phase>package</phase>
-          <goals>
-            <goal>shade</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-  </plugins>
-</build>
+            </filter>
+          </filters>
+          <!--
+          <artifactSet>
+            <excludes>
+              <exclude>org.jlab.coda:jclara</exclude>
+            </excludes>
+          </artifactSet>
+          -->
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -8,10 +8,10 @@
 
 
   <repositories>
-      <repository>
-        <id>clas12maven</id>
-        <url>https://clasweb.jlab.org/clas12maven</url> 
-      </repository>
+    <repository>
+      <id>clas12maven</id>
+      <url>https://clasweb.jlab.org/clas12maven</url> 
+    </repository>
   </repositories>
 
   <build>
@@ -36,7 +36,7 @@
     </plugins>
     -->
   </build>
-  
+
   <distributionManagement>
     <repository>
       <id>ssh-clasweb</id>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,5 @@
     <module>clas-geometry</module>
     <module>clas-detector</module>
     <module>clas-reco</module> 
-
   </modules>
-
 </project>


### PR DESCRIPTION
The Eclipse import was not working due to a missing source compatibility setting. This adds the proper compatibility level to support Java 8.

I've also formatted the POM files, and added a `.gitignore` file to exclude the output files generated by the compilation.